### PR TITLE
Migrate AVCA to Google Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,8 @@ The atlas is bootstrapped with [Tahoe’s](https://www.tahoebio.ai/) Tahoe-100M 
 
 [Documentation](./scBaseCount/README.md)
 
+# Virtual Cell Challenge
+
+[Documentation](./virtual-cell-challenge/README.md)
+
 > Note `scBaseCount` is the new name for `scBaseCamp`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 Arc Virtual Cell Atlas
 ======================
 
+> [!IMPORTANT]
+> **Data Migration Notice**: Arc's Virtual Cell Atlas data has migrated to the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute). 
+> 
+> **Note**: The new bucket is subject to [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays). Users can access up to 2TB of data per month for free before fees apply.
+> 
+> Access to the current GCS buckets (`gs://arc-ctc-tahoe100/` and `gs://arc-scbasecount/`) will be deprecated on **March 31, 2026**. Please update your workflows to use the Google Marketplace bucket `gs://arc-institute-virtual-cell-atlas`.
+
 The Arc Virtual Cell Atlas is a collection of high quality, curated, open datasets assembled for the purpose of accelerating the creation of virtual cell models.
 The atlas includes both observational and perturbational data from over 330 million cells (and growing).
 

--- a/scBaseCount/README.md
+++ b/scBaseCount/README.md
@@ -1,6 +1,13 @@
 scBaseCount
 ===========
 
+> [!IMPORTANT]
+> **Data Migration Notice**: This dataset is now available on the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute). 
+> 
+> **Note**: The new bucket is subject to [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays). Users can access up to 2TB of data per month for free before fees apply.
+> 
+> Access to the current GCS bucket (`gs://arc-scbasecount`) will be deprecated on **March 31, 2026**. Please update your workflows to use the Google Marketplace bucket `gs://arc-institute-virtual-cell-atlas`.
+
 ### An AI agent-curated, uniformly processed, and continually expanding single cell data repository
 
 <a href="https://arcinstitute.org/news/news/arc-virtual-cell-atlas-launch">
@@ -30,7 +37,10 @@ bioRxiv 2025.02.27.640494; doi: [https://doi.org/10.1101/2025.02.27.640494](http
 
 # Dataset location
 
-All data is located on a Google Cloud Storage bucket at `gs://arc-scbasecount`.
+* [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute) (Recommended)
+* Google Cloud Storage (Google Marketplace bucket: `gs://arc-institute-virtual-cell-atlas`)
+* Google Cloud Storage (Deprecated: access ends March 31, 2026)
+  * Path: `gs://arc-scbasecount`
 
 > WARNING: the previous location was `gs://arc-ctc-scbasecamp`, which is now deprecated and will be removed on Sunday, May 11, 2025.
 

--- a/scBaseCount/tutorial-R.ipynb
+++ b/scBaseCount/tutorial-R.ipynb
@@ -4,6 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### [!IMPORTANT]\n",
+    "**Data Migration Notice**: Arc's Virtual Cell Atlas data has migrated to the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute). \n",
+    "\n",
+    "**Note**: The new bucket is subject to [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays). Users can access up to 2TB of data per month for free before fees apply.\n",
+    "\n",
+    "Access to the current GCS buckets (`gs://arc-ctc-tahoe100/` and `gs://arc-scbasecount/`) will be deprecated on **March 31, 2026**. Please update your workflows to use the Google Marketplace bucket `gs://arc-institute-virtual-cell-atlas`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Summary\n",
     "\n",
     "* This is a tutorial on using R (& Python via [Reticulate](https://rstudio.github.io/reticulate/)) \n",
@@ -122,7 +134,7 @@
    "outputs": [],
    "source": [
     "# GCS bucket path\n",
-    "gcs_base_path = \"gs://arc-scbasecount/2025-02-25\""
+    "gcs_base_path = \"gs://arc-institute-virtual-cell-atlas/scbasecount/2025-02-25\""
    ]
   },
   {

--- a/scBaseCount/tutorial-py.ipynb
+++ b/scBaseCount/tutorial-py.ipynb
@@ -4,6 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### [!IMPORTANT]\n",
+    "**Data Migration Notice**: Arc's Virtual Cell Atlas data has migrated to the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute). \n",
+    "\n",
+    "**Note**: The new bucket is subject to [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays). Users can access up to 2TB of data per month for free before fees apply.\n",
+    "\n",
+    "Access to the current GCS buckets (`gs://arc-ctc-tahoe100/` and `gs://arc-scbasecount/`) will be deprecated on **March 31, 2026**. Please update your workflows to use the Google Marketplace bucket `gs://arc-institute-virtual-cell-atlas`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Summary\n",
     "\n",
     "* This is a tutorial on using Python for accessing the scBaseCount dataset hosted by the Arc Institute.\n",
@@ -75,7 +87,7 @@
    "outputs": [],
    "source": [
     "# GCS bucket path\n",
-    "gcs_base_path = \"gs://arc-scbasecount/2025-02-25/\""
+    "gcs_base_path = \"gs://arc-institute-virtual-cell-atlas/scbasecount/2025-02-25/\""
    ]
   },
   {

--- a/tahoe-100M/README.md
+++ b/tahoe-100M/README.md
@@ -1,14 +1,23 @@
 Tahoe-100M
 ==========
 
+> [!IMPORTANT]
+> **Data Migration Notice**: This dataset is now available on the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute). 
+> 
+> **Note**: The new bucket is subject to [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays). Users can access up to 2TB of data per month for free before fees apply.
+> 
+> Access to the current GCS bucket (`gs://arc-ctc-tahoe100/`) will be deprecated on **March 31, 2026**. Please update your workflows to use the Google Marketplace bucket `gs://arc-institute-virtual-cell-atlas`.
+
 # Overview
 
 * **Format:** 
   * Count matrices: h5ad (AnnData)
   * Metadata: Parquet
 * **Data host:** 
-  * Google Cloud Storage
-  * Path: `gs://arc-ctc-tahoe100/`
+  * [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute) (Recommended)
+  * Google Cloud Storage (Google Marketplace bucket: `gs://arc-institute-virtual-cell-atlas`)
+  * Google Cloud Storage (Deprecated: access ends March 31, 2026)
+    * Path: `gs://arc-ctc-tahoe100/`
 * **Statistics**
   * Sample count: 1344
   * Cell count: 100648790

--- a/tahoe-100M/tutorial-py.ipynb
+++ b/tahoe-100M/tutorial-py.ipynb
@@ -4,6 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### [!IMPORTANT]\n",
+    "**Data Migration Notice**: Arc's Virtual Cell Atlas data has migrated to the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute). \n",
+    "\n",
+    "**Note**: The new bucket is subject to [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays). Users can access up to 2TB of data per month for free before fees apply.\n",
+    "\n",
+    "Access to the current GCS buckets (`gs://arc-ctc-tahoe100/` and `gs://arc-scbasecount/`) will be deprecated on **March 31, 2026**. Please update your workflows to use the Google Marketplace bucket `gs://arc-institute-virtual-cell-atlas`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Summary\n",
     "\n",
     "* This is a tutorial on using Python for accessing the Tahoe-100M dataset hosted by the Arc Institute.\n",
@@ -75,7 +87,7 @@
    "outputs": [],
    "source": [
     "# GCS bucket path\n",
-    "gcp_base_path = \"gs://arc-ctc-tahoe100/2025-02-25/\""
+    "gcp_base_path = \"gs://arc-institute-virtual-cell-atlas/tahoe100M/2025-02-25/\""
    ]
   },
   {

--- a/virtual-cell-challenge/README.md
+++ b/virtual-cell-challenge/README.md
@@ -1,0 +1,52 @@
+Virtual Cell Challenge
+======================
+
+# Overview
+
+For Arc’s Virtual Cell Challenge, we generated a dedicated dataset measuring single-cell responses to perturbations in a human embryonic stem cell line (H1 hESC). This set of perturbations was carefully curated to span a broad range of phenotypic responses, and experimental parameters were optimized to maximize the reproducibility of observed effects. The Atlas includes the training, validation, and held-out test perturbation datasets leveraged throughout the Challenge.
+
+* **Format:**
+  * Count matrices: h5ad (AnnData)
+  * Metadata: Parquet & CSV
+* **Data host:**
+  * Google Marketplace bucket: `gs://arc-institute-virtual-cell-atlas/virtual-cell-challenge/`
+* **Statistics**
+  * Cell count: ~300,000 cells
+  * Target genes: 300
+
+## External Links
+
+* [Virtual Cell Challenge Datasets](https://virtualcellchallenge.org/datasets)
+* [Behind the Data of the Virtual Cell Challenge (Arc Blog)](https://arcinstitute.org/news/behind-the-data-virtual-cell-challenge)
+
+## Data Structure
+
+The data is organized by release year and split into training, validation, and test sets.
+
+```
+virtual-cell-challenge/
+└── 2025/
+    ├── test/
+    ├── train/
+    │   ├── adata_Training.h5ad
+    │   └── pert_counts_Training.csv
+    └── validation/
+```
+
+## Metrics
+
+The challenge evaluation framework centers around three metrics:
+
+* **Differential Expression Score (DES)**: Captures whether the model recovers the correct set of differentially expressed genes.
+* **Perturbation Discrimination Score (PDS)**: Measures whether the model assigns the correct effect to the correct perturbation.
+* **Mean Absolute Error (MAE)**: Assesses global expression accuracy across all genes.
+
+# Tutorials
+
+* [Python](./tutorial-py.ipynb)
+* [R](./tutorial-R.ipynb)
+
+# Contact
+
+* [GitHub Issues](https://github.com/ArcInstitute/arc-virtual-cell-atlas/issues)
+

--- a/virtual-cell-challenge/tutorial-R.ipynb
+++ b/virtual-cell-challenge/tutorial-R.ipynb
@@ -1,0 +1,10 @@
+{
+ "cells": [],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/virtual-cell-challenge/tutorial-R.ipynb
+++ b/virtual-cell-challenge/tutorial-R.ipynb
@@ -1,10 +1,118 @@
 {
- "cells": [],
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [!IMPORTANT]\n",
+    "**Data Migration Notice**: Arc's Virtual Cell Atlas data has migrated to the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute). \n",
+    "\n",
+    "**Note**: The new bucket is subject to [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays). Users can access up to 2TB of data per month for free before fees apply.\n",
+    "\n",
+    "Access to the current GCS buckets (`gs://arc-ctc-tahoe100/` and `gs://arc-scbasecount/`) will be deprecated on **March 31, 2026**. Please update your workflows to use the Google Marketplace bucket `gs://arc-institute-virtual-cell-atlas`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Summary\n",
+    "\n",
+    "* This is a tutorial on using R (& Python via [Reticulate](https://rstudio.github.io/reticulate/)) for accessing the Virtual Cell Challenge dataset.\n",
+    "* This dataset measures single-cell responses to perturbations in H1 hESCs.\n",
+    "* See the [README](README.md) for a description of the dataset and metrics."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation\n",
+    "\n",
+    "If needed, install the necessary dependencies.\n",
+    "\n",
+    "You can use the [conda environment](../conda_envs/R.yml) provided in this git repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(dplyr)\n",
+    "library(reticulate)\n",
+    "library(googleCloudStorageR)\n",
+    "\n",
+    "ad = import(\"anndata\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GCS bucket path for Virtual Cell Challenge 2025 datasets\n",
+    "vcc_base_path = \"gs://arc-institute-virtual-cell-atlas/virtual-cell-challenge/2025/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading Data\n",
+    "\n",
+    "Example of how to point to the training data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_adata_path = paste0(vcc_base_path, \"train/adata_Training.h5ad\")\n",
+    "print(train_adata_path)"
+   ]
+  }
+ ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "4.1.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }

--- a/virtual-cell-challenge/tutorial-py.ipynb
+++ b/virtual-cell-challenge/tutorial-py.ipynb
@@ -1,0 +1,16 @@
+{
+ "cells": [],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/virtual-cell-challenge/tutorial-py.ipynb
+++ b/virtual-cell-challenge/tutorial-py.ipynb
@@ -1,16 +1,176 @@
 {
- "cells": [],
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### [!IMPORTANT]\n",
+    "**Data Migration Notice**: Arc's Virtual Cell Atlas data has migrated to the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute). \n",
+    "\n",
+    "**Note**: The new bucket is subject to [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays). Users can access up to 2TB of data per month for free before fees apply.\n",
+    "\n",
+    "Access to the current GCS buckets (`gs://arc-ctc-tahoe100/` and `gs://arc-scbasecount/`) will be deprecated on **March 31, 2026**. Please update your workflows to use the Google Marketplace bucket `gs://arc-institute-virtual-cell-atlas`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Summary\n",
+    "\n",
+    "* This is a tutorial on using Python for accessing the Virtual Cell Challenge dataset hosted by the Arc Institute.\n",
+    "* The data can be streamed or downloaded locally.\n",
+    "  * For small jobs (e.g., summarizing metadata), streaming is recommended.\n",
+    "  * For large jobs (e.g., training a model), downloading is recommended.\n",
+    "* See the [README](README.md) for a description of the dataset and metrics."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation\n",
+    "\n",
+    "If needed, install the necessary dependencies.\n",
+    "\n",
+    "You can use the [conda environment](../conda_envs/python.yml) provided in this git repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import pandas as pd\n",
+    "import scanpy as sc\n",
+    "import gcsfs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initialize GCS file system for reading data from GCS\n",
+    "fs = gcsfs.GCSFileSystem()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GCS bucket path for Virtual Cell Challenge 2025 datasets\n",
+    "vcc_base_path = \"gs://arc-institute-virtual-cell-atlas/virtual-cell-challenge/2025/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading Data\n",
+    "\n",
+    "The training, validation, and test datasets are provided in `.h5ad` format (AnnData)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_adata_path = vcc_base_path + \"train/adata_Training.h5ad\"\n",
+    "val_adata_path = vcc_base_path + \"validation/adata_Validation.h5ad\"\n",
+    "\n",
+    "print(f\"Training data path: {train_adata_path}\")\n",
+    "print(f\"Validation data path: {val_adata_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Streaming Data\n",
+    "\n",
+    "To stream the data directly into memory using `scanpy`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# with fs.open(train_adata_path) as f:\n",
+    "#     adata = sc.read_h5ad(f)\n",
+    "# adata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Perturbation Counts\n",
+    "\n",
+    "CSV files with perturbation counts are also available for each split."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts_path = vcc_base_path + \"train/pert_counts_Training.csv\"\n",
+    "# counts = pd.read_csv(fs.open(counts_path))\n",
+    "# counts.head()"
+   ]
+  }
+ ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.2"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
# Pull Request: Data Migration and Virtual Cell Challenge Integration

This pull request updates the repository to reflect the migration of Arc's Virtual Cell Atlas data to the Google Cloud Marketplace and adds documentation and tutorials for the new Virtual Cell Challenge dataset.

## Changes

### 1. Data Migration & Deprecation Notices
*   Updated root `README.md`, `tahoe-100M/README.md`, and `scBaseCount/README.md` with a prominent notice regarding the migration to the [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/bigquery-public-data/arc-institute?project=gcp-public-data-arc-institute).
*   Added deprecation notices for legacy GCS buckets (`gs://arc-ctc-tahoe100/` and `gs://arc-scbasecount/`), with an end-of-life date of **March 31, 2026**.
*   Included information about the [Requester Pays](https://docs.cloud.google.com/storage/docs/requester-pays) policy for the new marketplace bucket, including the 2TB/month free tier.

### 2. Tutorial Updates
*   Updated existing tutorials in `tahoe-100M/` and `scBaseCount/` to point to the new consolidated GCS path: `gs://arc-institute-virtual-cell-atlas`.
*   Migrated tutorial paths to use the new subfolder structure:
    *   Tahoe-100M: `/tahoe100M/`
    *   scBaseCount: `/scbasecount/`
*   Added migration and "Requester Pays" notices to the top of all Python and R notebooks.

### 3. Virtual Cell Challenge Integration
*   Created a new `virtual-cell-challenge/` directory to house documentation and tutorials for the H1 hESC perturbation benchmark dataset.
*   Added `virtual-cell-challenge/README.md` with dataset descriptions, data structure (train/test/validation splits), and evaluation metrics (DES, PDS, MAE).
*   Created initial tutorial notebooks (`tutorial-py.ipynb` and `tutorial-R.ipynb`) for the challenge dataset.
*   Linked the Virtual Cell Challenge documentation from the root `README.md`.

## Impact
Users will now be directed to the recommended Google Cloud Marketplace bucket while having clear visibility into the upcoming deprecation of legacy storage paths. The addition of the Virtual Cell Challenge resources completes the Atlas documentation for the 2025 release.